### PR TITLE
Update roles to version 1.0.6

### DIFF
--- a/smart.json
+++ b/smart.json
@@ -8,6 +8,6 @@
   "packages": {
     "jquery-ui": "1.9.2",
     "jqbootstrapvalidation": "0.1.0",
-    "roles": "1.0.5"
+    "roles": "1.0.6"
   }
 }


### PR DESCRIPTION
Roles 1.0.5 does not work properly with meteor 0.6.5 and up.
See https://github.com/alanning/meteor-roles/commit/3d2b282de96273b4fdb34cfe54ce2def46f8d735
