### PR TITLE
Fix warning in Meteor 0.8 :

### DIFF
--- a/dialogs/edituser.html
+++ b/dialogs/edituser.html
@@ -21,10 +21,8 @@
 	  {{#each roles}}
 	  <label>
 	    <input type="checkbox" name="roles" value="{{name}}"
-	    {{#if hasrole}}
-	      checked
-	    {{/if}}
-	    >
+                {{checked}}
+            />
 	    {{name}}
 	  </label>
 	  {{/each}}

--- a/dialogs/edituser.js
+++ b/dialogs/edituser.js
@@ -67,5 +67,8 @@ Template.editUserDialog.helpers({
   },
   hasrole: function() {
     return Roles.userIsInRole(Template.editUserDialog.user, this.name);
+  },
+  checked: function() {
+    return Roles.userIsInRole(Template.editUserDialog.user, this.name)?"checked":"";
   }
 });


### PR DESCRIPTION
dialogs/edituser.html:24: Reactive HTML attributes must either have a constant name or consist of a single {{helper}} providing a dictionary of names and values.  A template tag of type BLOCKOPEN is not allowed here.
...alue="{{name}}"      {{#if hasrole}}        ...
