### PR TITLE
Fix #10 - Meteor 0.8.0 error with hasrole

### DIFF
--- a/dialogs/edituser.html
+++ b/dialogs/edituser.html
@@ -20,11 +20,7 @@
 	  <label>Roles</label>
 	  {{#each roles}}
 	  <label>
-	    <input type="checkbox" name="roles" value="{{name}}"
-	    {{#if hasrole}}
-	      checked
-	    {{/if}}
-	    >
+	    <input type="checkbox" name="roles" value="{{name}}" checked={{hasrole}}>
 	    {{name}}
 	  </label>
 	  {{/each}}


### PR DESCRIPTION
Fixes issue #10 by using boolean state properly for the Blaze templateing engine.
