### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In your iron-router configuration, add this:
 		  this.route('admin', {
 		    path: '/admin',
 		    template: 'adminusers',
-		    before: function() {
+		    onBeforeAction: function() {
 		      if (!Roles.userIsInRole(Meteor.user(), ['admin','user-admin'])) {
 		        this.redirect("/");
 		      }


### PR DESCRIPTION
'before' is now called 'onBeforeAction'. I got this deprecation notice with current `iron-router` and current `meteor`:

```
W20140627-16:20:24.764(2)? (STDERR) <deprecated> [RouteController] 'before' is deprecated. Please use 'onBeforeAction' instead.
```
